### PR TITLE
feat: add neumorphic design

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,15 +6,17 @@
   <title>NFL Season Predictions — Single‑File App</title>
   <style>
     :root {
-      --bg: #0b0f19;
-      --card: #121829;
-      --muted: #8a93a5;
-      --text: #e8ecf3;
-      --accent: #48c78e;
-      --accent-2: #5ab0f5;
-      --danger: #ff6b6b;
-      --warning: #ffb020;
-      --ring: rgba(90,176,245,0.4);
+      --bg: #e0e0e0;
+      --card: #e0e0e0;
+      --muted: #666666;
+      --text: #333333;
+      --accent: #b0b0b0;
+      --accent-2: #9e9e9e;
+      --danger: #a0a0a0;
+      --warning: #bbbbbb;
+      --ring: rgba(190,190,190,0.6);
+      --shadow-light: #ffffff;
+      --shadow-dark: #bebebe;
     }
     * { box-sizing: border-box; }
     html, body { height: 100%; }
@@ -22,7 +24,7 @@
       margin: 0;
       font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
       color: var(--text);
-      background: radial-gradient(1200px 1200px at 90% -10%, #1b2440 0%, #0b0f19 60%);
+      background: var(--bg);
     }
     a { color: var(--accent-2); text-decoration: none; }
     header {
@@ -117,6 +119,65 @@
     .hint {
       font-size: 12px; color: #bcd6ff; background: rgba(90,176,245,0.08); border: 1px solid var(--ring);
       padding: 8px 10px; border-radius: 10px;
+    }
+
+    /* Neumorphic overrides */
+    header,
+    .card,
+    .btn,
+    .team,
+    .chip,
+    select,
+    input[type="text"],
+    input[type="number"],
+    input[type="search"],
+    .tag,
+    .rank-badge {
+      background: var(--bg);
+      border: none;
+      color: var(--text);
+      box-shadow: 6px 6px 12px var(--shadow-dark),
+                  -6px -6px 12px var(--shadow-light);
+    }
+    .btn,
+    .chip,
+    .team {
+      transition: box-shadow .2s ease, transform .1s ease;
+    }
+    .btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 6px 6px 12px var(--shadow-dark),
+                  -6px -6px 12px var(--shadow-light);
+    }
+    .btn:active,
+    .chip:active,
+    .team:active {
+      box-shadow: inset 6px 6px 12px var(--shadow-dark),
+                  inset -6px -6px 12px var(--shadow-light);
+      transform: translateY(2px);
+    }
+    .chip.active {
+      box-shadow: inset 6px 6px 12px var(--shadow-dark),
+                  inset -6px -6px 12px var(--shadow-light);
+    }
+    header { backdrop-filter: none; }
+    .team.dragging {
+      opacity: .6;
+      box-shadow: inset 6px 6px 12px var(--shadow-dark),
+                  inset -6px -6px 12px var(--shadow-light);
+    }
+    .btn.accent,
+    .btn.warn,
+    .btn.danger {
+      background: var(--bg);
+      color: var(--text);
+    }
+    select,
+    input[type="text"],
+    input[type="number"],
+    input[type="search"] {
+      box-shadow: inset 6px 6px 12px var(--shadow-dark),
+                  inset -6px -6px 12px var(--shadow-light);
     }
 
     /* Print styles */


### PR DESCRIPTION
## Summary
- apply light gray monochromatic palette and dual shadows for a neumorphic look
- add pressed state animations and tactile shadows to interactive elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b88cea0ddc832ebc76fea23f13175a