### PR TITLE
Tone down neumorphic shadow highlights

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       --danger: #a0a0a0;
       --warning: #bbbbbb;
       --ring: rgba(90,176,245,0.6);
-      --shadow-light: #ffffff;
+      --shadow-light: rgba(255,255,255,0.06);
       --shadow-dark: #bebebe;
     }
     * { box-sizing: border-box; }


### PR DESCRIPTION
## Summary
- Use a subtle semi-transparent highlight for `--shadow-light` to better blend with the dark background
- Keep neumorphic `box-shadow` definitions but reference the updated `--shadow-light` color

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: could not find package.json)*
- `python3 -m http.server 8000 &` and `curl -s http://localhost:8000/index.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b8a6d4617c832ead4d4cb1932a2191