### PR TITLE
Apply new palette across app

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,17 +6,13 @@
   <title>NFL Season Predictions — Single‑File App</title>
   <style>
     :root {
-      --bg: #2e2e2e;
-      --card: #3a3a3a;
-      --muted: #aaaaaa;
-      --text: #e0e0e0;
-      --accent: #5ab0f5;
-      --accent-2: #4e81c9;
-      --danger: #a0a0a0;
-      --warning: #bbbbbb;
-      --ring: rgba(90,176,245,0.6);
-      --shadow-light: rgba(255,255,255,0.06);
-      --shadow-dark: #bebebe;
+      --bg: #f6f3ed;
+      --card: #c2cbd3;
+      --muted: rgba(49,56,81,0.65);
+      --text: #313851;
+      --accent: #313851;
+      --ring: rgba(49,56,81,0.25);
+      --border: rgba(49,56,81,0.18);
     }
     * { box-sizing: border-box; }
     html, body { height: 100%; margin: 0; background: var(--bg); }
@@ -24,7 +20,7 @@
       font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
       color: var(--text);
     }
-    a { color: var(--accent-2); text-decoration: none; }
+    a { color: var(--accent); text-decoration: none; }
     header {
       padding: 20px clamp(16px, 4vw, 40px);
       display: grid;
@@ -32,9 +28,9 @@
       gap: 16px;
       align-items: center;
       position: sticky; top: 0; z-index: 20;
-      background: linear-gradient(180deg, rgba(20,20,20,0.9), rgba(20,20,20,0.65) 60%, rgba(20,20,20,0));
-      backdrop-filter: blur(6px);
-      border-bottom: 1px solid rgba(255,255,255,0.06);
+      background: linear-gradient(180deg, rgba(194,203,211,0.9), rgba(194,203,211,0.65) 60%, rgba(194,203,211,0));
+      border-bottom: 1px solid var(--border);
+      box-shadow: 0 18px 32px rgba(49,56,81,0.12);
     }
     .title {
       font-size: clamp(20px, 2.2vw, 28px);
@@ -48,15 +44,34 @@
     }
     .actions { display: flex; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
     .btn {
-      background: #3a3a3a; color: var(--text);
-      border: 1px solid rgba(255,255,255,0.08);
+      background: rgba(194,203,211,0.35);
+      color: var(--text);
+      border: 1px solid var(--border);
       padding: 10px 14px; border-radius: 12px; font-weight: 600;
       cursor: pointer; transition: transform .06s ease, box-shadow .2s ease, border .2s ease;
+      box-shadow: 0 8px 18px rgba(49,56,81,0.12);
     }
-    .btn:hover { transform: translateY(-1px); box-shadow: 0 8px 20px rgba(0,0,0,0.25); border-color: rgba(90,176,245,0.35); }
-    .btn.accent { background: linear-gradient(180deg, #66d69f, #38b27a); color: #0b111b; border: none; }
-    .btn.warn { background: #2a2330; border-color: rgba(255,176,32,0.4); color: #ffd38a; }
-    .btn.danger { background: #2a2023; border-color: rgba(255,107,107,0.4); color: #ffb5b5; }
+    .btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 14px 28px rgba(49,56,81,0.2);
+      border-color: rgba(49,56,81,0.35);
+    }
+    .btn.accent {
+      background: var(--accent);
+      color: var(--bg);
+      border-color: var(--accent);
+      box-shadow: 0 16px 28px rgba(49,56,81,0.3);
+    }
+    .btn.warn {
+      background: transparent;
+      border-color: rgba(49,56,81,0.35);
+      color: var(--accent);
+    }
+    .btn.danger {
+      background: transparent;
+      border-color: rgba(49,56,81,0.35);
+      color: var(--accent);
+    }
 
     main { padding: 20px clamp(16px, 4vw, 40px) 80px; display: grid; gap: 28px; }
 
@@ -68,29 +83,60 @@
     @media (max-width: 800px) { .grid.cols-3, .grid.cols-2 { grid-template-columns: 1fr; } }
 
     .card {
-      background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02));
-      border: 1px solid rgba(255,255,255,0.08);
+      background: var(--card);
+      border: none;
       border-radius: 18px; padding: 16px 16px 14px; display: grid; gap: 12px; min-height: 0;
-      box-shadow: 0 6px 24px rgba(0,0,0,0.28), inset 0 1px 0 rgba(255,255,255,0.05);
+      box-shadow: 0 24px 40px rgba(49,56,81,0.16);
     }
-    .card h3 { margin: 0; font-size: 16px; letter-spacing: .4px; text-transform: uppercase; color: #b7c1d6; }
-    #superBowlCard h3 { text-transform: none; font-size: 18px; color: #ffffff; }
+    .card h3 { margin: 0; font-size: 16px; letter-spacing: .4px; text-transform: uppercase; color: var(--accent); }
+    #superBowlCard h3 { text-transform: none; font-size: 18px; color: var(--accent); }
     .sub { color: var(--muted); font-size: 12px; letter-spacing: .3px; }
 
     .division-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
-    .team { display: grid; grid-template-columns: 28px 1fr auto; align-items: center; gap: 10px; padding: 10px 12px; border-radius: 12px; background: #1f1f1f; border: 1px solid rgba(255,255,255,0.08); cursor: grab; user-select: none; }
+    .team {
+      display: grid; grid-template-columns: 28px 1fr auto; align-items: center; gap: 10px; padding: 10px 12px; border-radius: 12px;
+      background: rgba(246,243,237,0.85);
+      border: 1px solid var(--border);
+      box-shadow: 0 6px 12px rgba(49,56,81,0.12);
+      cursor: grab; user-select: none;
+    }
     .team.dragging { opacity: .6; border-style: dashed; }
-    .handle { width: 18px; opacity: .6; }
-    .rank-badge { width: 28px; height: 28px; border-radius: 10px; display: grid; place-items: center; font-weight: 700; background: #2f2f2f; border: 1px solid rgba(255,255,255,0.08); color: #9db5ff; }
+    .handle { width: 18px; opacity: .5; }
+    .rank-badge {
+      width: 28px; height: 28px; border-radius: 10px; display: grid; place-items: center; font-weight: 700;
+      background: var(--accent);
+      color: var(--bg);
+      box-shadow: 0 4px 8px rgba(49,56,81,0.2);
+    }
 
     .chips { display: flex; gap: 8px; flex-wrap: wrap; }
-    .chip { padding: 8px 12px; border-radius: 999px; border: 1px solid rgba(255,255,255,0.1); background: #1f1f1f; cursor: pointer; color: var(--text); }
-    .chip.active { background: linear-gradient(180deg, rgba(90,176,245,0.18), rgba(90,176,245,0.08)); border-color: var(--ring); box-shadow: 0 0 0 3px var(--ring); color: #fff; }
+    .chip {
+      padding: 8px 12px; border-radius: 999px; border: 1px solid var(--border);
+      background: rgba(246,243,237,0.8);
+      cursor: pointer; color: var(--text);
+      transition: box-shadow .2s ease, transform .06s ease;
+    }
+    .chip:hover { transform: translateY(-1px); box-shadow: 0 6px 14px rgba(49,56,81,0.14); }
+    .chip.active {
+      background: var(--accent);
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(49,56,81,0.2);
+      color: var(--bg);
+    }
     .count { font-size: 12px; color: var(--muted); }
 
     .bracket { list-style: none; margin: 0; padding: 0; display: grid; gap: 6px; }
-    .bracket li { display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: 8px; background: #1f1f1f; border: 1px solid rgba(255,255,255,0.08); }
-    .bracket .seed { width: 22px; height: 22px; border-radius: 6px; background: #2f2f2f; display: grid; place-items: center; font-size: 12px; font-weight: 700; color: #9db5ff; }
+    .bracket li {
+      display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: 8px;
+      background: rgba(246,243,237,0.85);
+      border: 1px solid var(--border);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.3);
+    }
+    .bracket .seed {
+      width: 22px; height: 22px; border-radius: 6px; background: var(--accent);
+      display: grid; place-items: center; font-size: 12px; font-weight: 700; color: var(--bg);
+      box-shadow: 0 4px 8px rgba(49,56,81,0.25);
+    }
     .bracket .spacer { flex: 1; }
     .btn.sm {
       padding: 6px 10px;
@@ -98,14 +144,14 @@
       border-radius: 10px;
       background: transparent;
       box-shadow: none;
-      border: 1px solid rgba(255,255,255,0.12);
+      border: 1px solid rgba(49,56,81,0.2);
       color: var(--muted);
     }
     .btn.sm:hover {
       transform: none;
       box-shadow: none;
       color: var(--text);
-      border-color: rgba(90,176,245,0.35);
+      border-color: rgba(49,56,81,0.35);
     }
     .btn.sm:active {
       box-shadow: none;
@@ -113,12 +159,13 @@
     }
 
     select, input[type="text"], input[type="number"], input[type="search"] {
-      width: 100%; padding: 10px 12px; border-radius: 10px; background: #1a1a1a; color: var(--text);
-      border: 1px solid rgba(255,255,255,0.1);
-      outline: none; box-shadow: 0 0 0 0 var(--ring);
+      width: 100%; padding: 10px 12px; border-radius: 10px;
+      background: rgba(246,243,237,0.9); color: var(--text);
+      border: 1px solid var(--border);
+      outline: none; box-shadow: inset 0 1px 2px rgba(49,56,81,0.12);
       transition: box-shadow .2s ease, border .2s ease;
     }
-    select:focus, input:focus { border-color: var(--ring); box-shadow: 0 0 0 3px var(--ring); }
+    select:focus, input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--ring); }
 
     .row { display: grid; gap: 12px; grid-template-columns: 1fr 1fr; }
     @media (max-width: 800px) { .row { grid-template-columns: 1fr; } }
@@ -128,72 +175,27 @@
 
     .stack { display: grid; gap: 8px; }
 
-    .divider { height: 1px; background: linear-gradient(90deg, rgba(255,255,255,0.04), rgba(255,255,255,0.12), rgba(255,255,255,0.04)); margin: 4px 0; }
+    .divider { height: 1px; background: linear-gradient(90deg, rgba(49,56,81,0.1), rgba(49,56,81,0.25), rgba(49,56,81,0.1)); margin: 4px 0; }
 
     .help { font-size: 12px; color: var(--muted); }
 
     .hint {
-      font-size: 12px; color: #bcd6ff; background: rgba(90,176,245,0.08); border: 1px solid var(--ring);
+      font-size: 12px; color: var(--accent);
+      background: rgba(49,56,81,0.08); border: 1px solid var(--ring);
       padding: 8px 10px; border-radius: 10px;
-    }
-
-    /* Neumorphic overrides */
-    header,
-    .card,
-    .btn,
-    .team,
-    .chip,
-    select,
-    input[type="text"],
-    input[type="number"],
-    input[type="search"],
-    .tag,
-    .rank-badge {
-      background: var(--bg);
-      border: none;
-      color: var(--text);
-      box-shadow: 6px 6px 12px var(--shadow-dark),
-                  -6px -6px 12px var(--shadow-light);
-    }
-    .btn,
-    .chip,
-    .team {
-      transition: box-shadow .2s ease, transform .1s ease;
-    }
-    .btn:hover {
-      transform: translateY(-1px);
-      box-shadow: 6px 6px 12px var(--shadow-dark),
-                  -6px -6px 12px var(--shadow-light);
     }
     .btn:active,
     .chip:active,
     .team:active {
-      box-shadow: inset 6px 6px 12px var(--shadow-dark),
-                  inset -6px -6px 12px var(--shadow-light);
+      box-shadow: inset 0 3px 6px rgba(49,56,81,0.18);
       transform: translateY(2px);
     }
-    .chip.active {
-      box-shadow: inset 6px 6px 12px var(--shadow-dark),
-                  inset -6px -6px 12px var(--shadow-light);
+    .chip.active:active {
+      box-shadow: inset 0 3px 6px rgba(0,0,0,0.18);
     }
-    header { backdrop-filter: none; }
     .team.dragging {
       opacity: .6;
-      box-shadow: inset 6px 6px 12px var(--shadow-dark),
-                  inset -6px -6px 12px var(--shadow-light);
-    }
-    .btn.accent,
-    .btn.warn,
-    .btn.danger {
-      background: var(--bg);
-      color: var(--text);
-    }
-    select,
-    input[type="text"],
-    input[type="number"],
-    input[type="search"] {
-      box-shadow: inset 6px 6px 12px var(--shadow-dark),
-                  inset -6px -6px 12px var(--shadow-light);
+      box-shadow: inset 0 4px 6px rgba(49,56,81,0.18);
     }
 
     /* Print styles */

--- a/summary.html
+++ b/summary.html
@@ -5,24 +5,40 @@
   <title>NFL Predictions Summary</title>
   <style>
     :root {
-      --bg: #2e2e2e;
-      --card: #3a3a3a;
-      --muted: #aaaaaa;
-      --text: #e0e0e0;
+      --bg: #f6f3ed;
+      --card: #c2cbd3;
+      --muted: rgba(49,56,81,0.65);
+      --text: #313851;
+      --accent: #313851;
+      --border: rgba(49,56,81,0.18);
     }
     * { box-sizing: border-box; }
     html, body { height: 100%; margin: 0; background: var(--bg); color: var(--text); font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
-    a { color: var(--text); text-decoration: none; }
-    header { display: flex; align-items: center; justify-content: space-between; padding: 20px clamp(16px,4vw,40px); }
-    .btn { background: #3a3a3a; color: var(--text); border: 1px solid rgba(255,255,255,0.08); padding: 10px 14px; border-radius: 12px; font-weight: 600; cursor: pointer; }
+    a { color: var(--accent); text-decoration: none; }
+    header {
+      display: flex; align-items: center; justify-content: space-between; padding: 20px clamp(16px,4vw,40px);
+      background: var(--card);
+      border-bottom: 1px solid var(--border);
+      box-shadow: 0 12px 26px rgba(49,56,81,0.16);
+    }
+    .btn {
+      background: var(--accent);
+      color: var(--bg);
+      border: none;
+      padding: 10px 14px; border-radius: 12px; font-weight: 600; cursor: pointer;
+      box-shadow: 0 12px 22px rgba(49,56,81,0.25);
+      transition: transform .06s ease, box-shadow .2s ease;
+    }
+    .btn:hover { transform: translateY(-1px); box-shadow: 0 16px 28px rgba(49,56,81,0.3); }
+    .btn:active { transform: translateY(2px); box-shadow: inset 0 4px 8px rgba(0,0,0,0.2); }
     main { padding: 20px clamp(16px,4vw,40px); display: grid; grid-template-columns: 2fr 1fr; gap: 24px; }
     @media (max-width: 900px) { main { grid-template-columns: 1fr; } }
-    .card { background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)); border: 1px solid rgba(255,255,255,0.08); border-radius: 18px; padding: 16px; box-shadow: 0 6px 24px rgba(0,0,0,0.28), inset 0 1px 0 rgba(255,255,255,0.05); }
-    .card h3 { margin-top: 0; text-transform: uppercase; font-size: 16px; color: #b7c1d6; }
+    .card { background: var(--card); border: none; border-radius: 18px; padding: 16px; box-shadow: 0 20px 36px rgba(49,56,81,0.18); }
+    .card h3 { margin-top: 0; text-transform: uppercase; font-size: 16px; color: var(--accent); }
     .division-grid { display: grid; grid-template-columns: repeat(2,1fr); gap: 16px; }
     ol { margin: 0; padding-left: 20px; }
     .tags { display: flex; flex-wrap: wrap; gap: 6px; }
-    .tag { padding: 4px 8px; border-radius: 999px; border: 1px solid #666; background: #1f1f1f; }
+    .tag { padding: 4px 8px; border-radius: 999px; border: 1px solid var(--border); background: rgba(246,243,237,0.85); color: var(--text); }
     .label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: .3px; }
     .stack { display: grid; gap: 8px; }
     .muted { color: var(--muted); }


### PR DESCRIPTION
## Summary
- restyle the main predictions page to use the requested navy and cream palette
- update the summary view to match the refreshed color scheme

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb5b7b0254832e8d35b39b78faf132